### PR TITLE
Add type-safe checking for createSequence where large values (BigInteger...

### DIFF
--- a/src/main/groovy/com/augusttechgroup/liquibase/delegate/ChangeSetDelegate.groovy
+++ b/src/main/groovy/com/augusttechgroup/liquibase/delegate/ChangeSetDelegate.groovy
@@ -58,6 +58,8 @@ import liquibase.change.custom.CustomChangeWrapper
 import liquibase.exception.RollbackImpossibleException
 import liquibase.change.core.ModifyDataTypeChange
 import liquibase.change.core.DeleteDataChange
+import org.codehaus.groovy.runtime.typehandling.GroovyCastException
+import java.math.BigInteger
 
 
 class ChangeSetDelegate {
@@ -453,9 +455,20 @@ class ChangeSetDelegate {
 
   private def makeChangeFromMap(Class klass, Map sourceMap, List paramNames) {
     def change = klass.newInstance()
+
     paramNames.each { name ->
       if(sourceMap[name] != null) {
-        change[name] = sourceMap[name]
+        try {
+            change[name] = sourceMap[name]
+        }
+        catch (GroovyCastException ex) {
+           if(sourceMap[name].isBigInteger()) {
+             change[name] = sourceMap[name].toBigInteger()
+           }
+           else {
+               throw ex
+           }
+         }
       }
     }
 

--- a/src/test/groovy/com/augusttechgroup/liquibase/delegate/DataQualityRefactoringTests.groovy
+++ b/src/test/groovy/com/augusttechgroup/liquibase/delegate/DataQualityRefactoringTests.groovy
@@ -167,7 +167,37 @@ class DataQualityRefactoringTests
     assertEquals 'sequence', changes[0].sequenceName
   }
 
+  @Test
+  void createTypeSafeSequence() {
+    buildChangeSet {
+      createSequence(sequenceName: 'typeSafeSequence', schemaName: 'schema', incrementBy: 42, minValue: 7, maxValue: "999999999999999999999999999", ordered: true, startValue: "1000000")
+    }
 
+    def changes = changeSet.changes
+    assertNotNull changes
+    assertEquals 1, changes.size()
+    assertTrue changes[0] instanceof CreateSequenceChange
+    assertEquals 'typeSafeSequence', changes[0].sequenceName
+    assertEquals 'schema', changes[0].schemaName
+    assertEquals 42G, changes[0].incrementBy
+    assertEquals 7G, changes[0].minValue
+    assertEquals 999999999999999999999999999 as BigInteger, changes[0].maxValue
+    assertEquals 1000000 as BigInteger, changes[0].startValue
+    assertTrue changes[0].ordered
+  }
+
+  @Test
+  void dropTypeSafeSequence() {
+    buildChangeSet {
+      dropSequence(sequenceName: 'typeSafeSequence')
+    }
+
+    def changes = changeSet.changes
+    assertNotNull changes
+    assertEquals 1, changes.size()
+    assertTrue changes[0] instanceof DropSequenceChange
+    assertEquals 'typeSafeSequence', changes[0].sequenceName
+  }
 
   @Test
   void addAutoIncrement() {


### PR DESCRIPTION
...) are defined within double-quotes. Otherwise a GroovyCastException is thrown.
