### PR TITLE
Patch for single file inclusion through spring's classpath resource accessor

### DIFF
--- a/src/main/groovy/com/augusttechgroup/liquibase/delegate/DatabaseChangeLogDelegate.groovy
+++ b/src/main/groovy/com/augusttechgroup/liquibase/delegate/DatabaseChangeLogDelegate.groovy
@@ -119,7 +119,12 @@ class DatabaseChangeLogDelegate {
             includeChangeLog(params.path + name)
           }
         } else {
-          includeChangeLog(params.path + file.name)
+          //single file inclusion
+          if (params.path.endsWith("/")) {
+            //remove the last slash (it could have only been added some lines above)
+            params.path = params.path[0..-2]
+          }
+          includeChangeLog(params.path) //directly include the file identified by the path param
         }
       }
     }


### PR DESCRIPTION
Just avoid having a file not found for _path/to/mychangelog.groovy/mychangelog.groovy_ when including a single changeset file this way

``` groovy
include(path: 'path/to/mychangelog.groovy', relativeToChangelog: false)
```

(proposed refinement for [pull request 31](https://github.com/tlberglund/groovy-liquibase/pull/31), see https://github.com/tlberglund/groovy-liquibase/issues/28 ) 
