### PR TITLE
fix using different versions of groovy library in compile time and runti...

### DIFF
--- a/liquibase.gradle
+++ b/liquibase.gradle
@@ -6,7 +6,7 @@ repositories {
 }
 
 dependencies {
-  groovy 'org.codehaus.groovy:groovy:1.7.5'
+  runtime 'org.codehaus.groovy:groovy:1.8.6'
   runtime 'org.liquibase:liquibase-core:3.1.1'
   runtime 'mysql:mysql-connector-java:5.1.9'
 }


### PR DESCRIPTION
Get this error if I try to execute an update with the integrated gradle:
Caused by: java.lang.ClassNotFoundException: org.codehaus.groovy.runtime.BytecodeInterface8
	at java.net.URLClassLoader$1.run(URLClassLoader.java:366)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:355)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:354)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:425)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:308)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:358)
	... 4 more
